### PR TITLE
FEATURE apply discounts to products

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -4,3 +4,11 @@ name: silverstripe-foxy-discounts-config
 Dynamic\Foxy\Model\Setting:
   extensions:
     - Dynamic\Foxy\Discounts\Extension\FoxyAdminExtension
+
+Dynamic\Products\Page\Product:
+  extensions:
+    - Dynamic\Foxy\Discounts\Extension\ProductDataExtension
+
+PageController:
+  extensions:
+    - Dynamic\Foxy\Discounts\Extension\PageControllerExtension

--- a/src/Extension/FoxyAdminExtension.php
+++ b/src/Extension/FoxyAdminExtension.php
@@ -2,7 +2,7 @@
 
 namespace Dynamic\Foxy\Discounts\Extension;
 
-use Dynamic\Foxy\Discount\Model\Discount;
+use Dynamic\Foxy\Discounts\Model\Discount;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;

--- a/src/Extension/PageControllerExtension.php
+++ b/src/Extension/PageControllerExtension.php
@@ -21,9 +21,9 @@ class PageControllerExtension extends Extension
                 HiddenField::create(AddToCartForm::getGeneratedValue(
                     $code,
                     'discount_quantity_percentage',
-                    $this->getDiscountFieldValue())
-                )->setValue($this->getDiscountFieldValue()
-            ));
+                    $this->getDiscountFieldValue()
+                ))->setValue($this->getDiscountFieldValue())
+            );
         }
     }
 

--- a/src/Extension/PageControllerExtension.php
+++ b/src/Extension/PageControllerExtension.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Dynamic\Foxy\Discounts\Extension;
+
+use Dynamic\Foxy\Form\AddToCartForm;
+use Dynamic\Foxy\Model\FoxyHelper;
+use SilverStripe\Core\Extension;
+use SilverStripe\Forms\HiddenField;
+
+class PageControllerExtension extends Extension
+{
+    /**
+     * @param $form
+     */
+    public function updateAddToCartForm(&$form)
+    {
+        if ($this->owner->data()->getActiveDiscount()) {
+            $code = $this->owner->data()->Code;
+            $fields = $form->Fields();
+            $fields->push(
+                HiddenField::create(AddToCartForm::getGeneratedValue(
+                    $code,
+                    'discount_quantity_percentage',
+                    $this->getDiscountFieldValue())
+                )->setValue($this->getDiscountFieldValue()
+            ));
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getDiscountFieldValue()
+    {
+        if ($discount = $this->owner->data()->getActiveDiscount()) {
+            $string = "|{$discount->Quantity}-{$discount->Percentage}";
+            return "{$discount->Title}{allunits{$string}}";
+        }
+        return false;
+    }
+}

--- a/src/Extension/ProductDataExtension.php
+++ b/src/Extension/ProductDataExtension.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Dynamic\Foxy\Discounts\Extension;
+
+use Dynamic\Foxy\Discounts\Model\Discount;
+use SilverStripe\ORM\DataExtension;
+
+class ProductDataExtension extends DataExtension
+{
+    /**
+     * @var array
+     */
+    private static $belongs_many_many = [
+        'Discounts' => Discount::class,
+    ];
+
+    /**
+     * @return bool|float|int|mixed
+     */
+    public function getDiscountPrice()
+    {
+        if ($discount = $this->getActiveDiscount()) {
+            $price = $this->owner->Price - ($this->owner->Price * ($this->getActiveDiscount()->Percentage/100));
+            return $price;
+        }
+        return false;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getActiveDiscount()
+    {
+        $filter = [
+            'StartTime:LessThanOrEqual' => date("Y-m-d H:i:s", strtotime('now')),
+            'EndTime:GreaterThanOrEqual' => date("Y-m-d H:i:s", strtotime('now')),
+        ];
+
+        if ($this->owner->Discounts()->filter($filter)->count() > 0) {
+            foreach ($this->owner->Discounts()->filter($filter)->sort('Percentage DESC') as $discount) {
+                if ($discount->getIsActive()) {
+                    return $discount;
+                }
+            }
+        }
+
+        foreach (Discount::get()->filter($filter)->sort('Percentage DESC') as $discount) {
+            if ($discount->getIsGlobal()) {
+                return $discount;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Extension/ProductDataExtension.php
+++ b/src/Extension/ProductDataExtension.php
@@ -20,7 +20,7 @@ class ProductDataExtension extends DataExtension
     public function getDiscountPrice()
     {
         if ($discount = $this->getActiveDiscount()) {
-            $price = $this->owner->Price - ($this->owner->Price * ($this->getActiveDiscount()->Percentage/100));
+            $price = $this->owner->Price - ($this->owner->Price * ($this->getActiveDiscount()->Percentage / 100));
             return $price;
         }
         return false;

--- a/tests/Model/DIscountTest.php
+++ b/tests/Model/DIscountTest.php
@@ -2,7 +2,7 @@
 
 namespace Dynamic\Foxy\Discounts\Test\Model;
 
-use Dynamic\Foxy\Discount\Model\Discount;
+use Dynamic\Foxy\Discounts\Model\Discount;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\FieldList;

--- a/tests/fixtures.yml
+++ b/tests/fixtures.yml
@@ -45,6 +45,6 @@ SilverStripe\Security\Member:
     Email: "user"
     Password: "user"
 
-Dynamic\Foxy\Discount\Model\Discount:
+Dynamic\Foxy\Discounts\Model\Discount:
   one:
     Title: 'Black Friday Sale'


### PR DESCRIPTION
implements `$DiscountPrice` on Product

Discounts can be applied to existing products via many_many. If no products are selected, the discount is considered global.

Discounts are versioned and can be published or draft. They are also datetime based, and will only be considered active between start and end dates.

note - updated malformed namespaces on a couple classes