### PR TITLE
NEW AddToCartFormExtension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "dynamic/silverstripe-foxy": "^1.0"
+        "dynamic/silverstripe-foxy": "^1.3.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/src/Extension/AddToCartFormExtension.php
+++ b/src/Extension/AddToCartFormExtension.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Dynamic\Foxy\Discounts\Extension;
+
+use Dynamic\Foxy\Discounts\DiscountHelper;
+use Dynamic\Foxy\Form\AddToCartForm;
+use SilverStripe\Core\Extension;
+
+/**
+ * Class AddToCartFormExtension
+ * @package Dynamic\Foxy\Discounts\Extension
+ *
+ * @property-read AddToCartFormExtension|AddToCartForm $owner
+ */
+class AddToCartFormExtension extends Extension
+{
+    /**
+     * @param $fields
+     * @throws \Exception
+     */
+    public function updateProductFields(&$fields)
+    {
+        $page = $this->owner->getProduct();
+        if ($this->getIsDiscountable($page)) {
+            /** @var DiscountHelper $discount */
+            if ($discount = $page->getBestDiscount()) {
+                $expirationMinutes = $this->resolveDiscountExpiration($discount->getDiscount()->EndTime);
+
+                $this->owner->getExpirationHelper()->addExpiration($expirationMinutes);
+            }
+        }
+    }
+
+    /**
+     * @param $product
+     * @return bool
+     */
+    protected function getIsDiscountable($product)
+    {
+        return $product->hasMethod('getHasDiscount')
+            && $product->hasMethod('getBestDiscount')
+            && $product->getHasDiscount();
+    }
+
+    /**
+     * @param $endTime
+     * @return float|int|string
+     * @throws \Exception
+     */
+    protected function resolveDiscountExpiration($endTime)
+    {
+        $expiration = new \DateTime($endTime, new \DateTimeZone('America/Chicago'));
+        $now = new \DateTime('now', new \DateTimeZone('America/Chicago'));
+        $diff = $now->diff($expiration);
+
+        $days = $diff->format('%a');
+        $hours = $diff->format('%H');
+        $minutes = $diff->format('%I');
+
+        $totalMinutes = (((($days * 24) + $hours) * 60) + $minutes);
+
+        return $totalMinutes;
+    }
+}

--- a/src/Extension/PageControllerExtension.php
+++ b/src/Extension/PageControllerExtension.php
@@ -57,17 +57,6 @@ class PageControllerExtension extends Extension
                         ))->setValue($this->getDiscountFieldValue())
                             ->addExtraClass('product-discount')
                     );
-
-                    if ($discount->getDiscount()->EndTime) {
-                        $fields->push(
-                            HiddenField::create(AddToCartForm::getGeneratedValue(
-                                $code,
-                                'expires',
-                                strtotime($discount->getDiscount()->EndTime)
-                            ))
-                                ->setValue(strtotime($discount->getDiscount()->EndTime))
-                        );
-                    }
                 }
             }
         }


### PR DESCRIPTION
Utilize ProductExpirationHelper on AddToCartForm.

Currently there is no way for multiple foxy modules implementing an expires to intelligently determine the lowest time in minutes. The helper does that for us.

Depends on dynamic/silverstripe-foxy#121